### PR TITLE
Creates the services and endpoints to create accounts.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # gem 'rack-cors'
 
 gem 'ancestry', '~> 3.0'
+gem 'active_model_serializers', '~> 0.10.7'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.7)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.2.0)
       activesupport (= 5.2.0)
       globalid (>= 0.3.6)
@@ -52,6 +57,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
@@ -83,6 +90,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    jsonapi-renderer (0.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -196,6 +204,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.7)
   ancestry (~> 3.0)
   annotate (~> 2.7)
   bootsnap (>= 1.1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+  include ExceptionHandler
 end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -1,0 +1,13 @@
+module ExceptionHandler
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from ActiveRecord::RecordNotFound do |e|
+      render json: { message: e.message }, status: :not_found
+    end
+
+    rescue_from ActiveRecord::RecordInvalid do |e|
+      render json: { message: e.message }, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/v1/accounts_controller.rb
+++ b/app/controllers/v1/accounts_controller.rb
@@ -1,0 +1,35 @@
+class V1::AccountsController < ApplicationController
+  before_action :set_account, only: %i[show update destroy]
+
+  def show
+    @account = Account.find params[:id]
+    render json: @account, status: :ok
+  end
+
+  def create
+    @account = Account::Create.call(account_params)
+    render json: @account, status: :created
+  end
+
+  def update
+    @account = Account::Update.call(account_params, @account.id)
+    render json: @account, status: :ok
+  end
+
+  def destroy
+    @account.destroy
+    render status: :no_content
+  end
+
+  private
+
+  def set_account
+    @account = Account.find params[:id]
+  end
+
+  def account_params
+    params.require(:account)
+          .permit(:parent_id, :name, :person_type, :birthdate, :cnpj,
+                  :cpf, :full_name, :social_name, :trade_name, :account_status)
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -19,7 +19,6 @@
 class Account < ApplicationRecord
   has_ancestry
   has_one :person, dependent: :destroy
-  accepts_nested_attributes_for :person
 
   enum account_status: %i[active blocked canceled]
   enum account_type: %i[matrix branch]

--- a/app/serializers/account_serializer.rb
+++ b/app/serializers/account_serializer.rb
@@ -1,0 +1,4 @@
+class AccountSerializer < ActiveModel::Serializer
+  attributes :id, :name, :account_status, :account_type, :balance
+  has_one :person
+end

--- a/app/services/account/create.rb
+++ b/app/services/account/create.rb
@@ -1,0 +1,65 @@
+class Account::Create < ApplicationService
+  def initialize(params)
+    @birthdate   = params[:birthdate]
+    @cpf         = params[:cpf]
+    @cnpj        = params[:cnpj]
+    @full_name   = params[:full_name]
+    @name        = params[:name]
+    @parent_id   = params[:parent_id]
+    @person_type = params[:person_type]
+    @trade_name  = params[:trade_name]
+    @social_name = params[:social_name]
+  end
+
+  def call
+    create_account
+  end
+
+  private
+
+  def create_account
+    ActiveRecord::Base.transaction do
+      account = Account.new.tap do |a|
+        a.account_type = account_type
+        a.account_status = :active
+        a.name = @name
+        a.parent_id = parent_id
+        a.save!
+      end
+
+      if corporation?
+        Corporation.create(cnpj: @cnpj, social_name: @social_name,
+                           trade_name: @trade_name, account_id: account.id)
+      else
+        Individual.create(cpf: @cpf, full_name: @full_name,
+                          birthdate: @birthdate, account_id: account.id)
+      end
+
+      account.reload
+    end
+  end
+
+  def account_type
+    parent? ? :branch : :matrix
+  end
+
+  def parent_id
+    parent? ? @parent_id : nil
+  end
+
+  def corporation?
+    if person? && @person_type.casecmp('corporation').zero?
+      true
+    else
+      false
+    end
+  end
+
+  def parent?
+    @parent_id.present? ? true : false
+  end
+
+  def person?
+    @person_type.present? ? true : false
+  end
+end

--- a/app/services/account/update.rb
+++ b/app/services/account/update.rb
@@ -1,0 +1,41 @@
+class Account::Update < ApplicationService
+  def initialize(params, account_id)
+    @account_id     = account_id
+    @account_status = params[:account_status]
+    @birthdate      = params[:birthdate]
+    @cpf            = params[:cpf]
+    @cnpj           = params[:cnpj]
+    @full_name      = params[:full_name]
+    @name           = params[:name]
+    @trade_name     = params[:trade_name]
+    @social_name    = params[:social_name]
+  end
+
+  def call
+    update_account
+  end
+
+  private
+
+  def update_account
+    ActiveRecord::Base.transaction do
+      account = Account.find @account_id
+      account.tap do |a|
+        a.account_status = @account_status if @account_status
+        a.name = @name if @name
+        a.person.tap do |p|
+          p.birthdate   = @birthdate if @birthdate
+          p.cnpj        = @cnpj if @cnpj
+          p.cpf         = @cpf if @cpf
+          p.full_name   = @full_name if @full_name
+          p.social_name = @social_name if @social_name
+          p.trade_name  = @trade_name if @trade_name
+          p.save
+        end
+        a.save
+      end
+
+      account.reload
+    end
+  end
+end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,5 @@
+class ApplicationService
+  def self.call(*args, &block)
+    new(*args, &block).call
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,8 @@ module Hubfintech
     config.generators do |g|
       g.test_framework :rspec,
         helper_specs: false,
-        routing_specs: false
+        routing_specs: false,
+        controller_specs: false
     end
   end
 end

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,0 +1,1 @@
+ActiveModel::Serializer.config.adapter = :json_api

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :v1, defaults: { format: :json } do
+    resources :accounts, only: %i[show create update destroy]
+  end
 end

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,0 +1,26 @@
+FactoryBot.define do
+  factory :account do
+    trait :active do
+      account_status :active
+    end
+
+    trait :blocked do
+      account_status :blocked
+    end
+
+    trait :canceled do
+      account_status :canceled
+    end
+
+    trait :matrix do
+      account_type :matrix
+    end
+
+    trait :branch do
+      account_type :branch
+    end
+
+    name 'Account Name'
+    balance 0.0
+  end
+end

--- a/spec/factories/corporations.rb
+++ b/spec/factories/corporations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :corporation, parent: :person, class: 'Corporation' do
+    cnpj '12345678901234'
+    social_name 'Test Company'
+    trade_name 'Test Company 2'
+  end
+end

--- a/spec/factories/individuals.rb
+++ b/spec/factories/individuals.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :individual, parent: :person, class: 'Individual' do
+    cpf '12345678901'
+    full_name 'Joe Doe'
+    birthdate '20/08/1900'
+  end
+end

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :person, class: 'Person' do
+  end
+end
+

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -51,6 +51,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include RequestSpecHelper, type: :request
 
   config.include FactoryBot::Syntax::Methods
 end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe 'Accounts', type: :request do
+  let!(:account) { create(:account, :active, :matrix) }
+  let(:account_id) { account.id }
+  let!(:corporation) { create(:corporation, account_id: account_id) }
+
+  describe 'GET /v1/accounts/:id' do
+    before { get "/v1/accounts/#{account_id}" }
+
+    context 'when the record exists' do
+      it 'returns the account' do
+        expect(json_data).not_to be_empty
+        expect(json_data[:data][:id].to_i).to eq(account_id)
+      end
+
+      it 'returns the status code 200' do
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  describe 'POST /v1/accounts' do
+    let(:account_attributes) do
+      {
+        account: {
+          name: 'Test Account',
+          person_type: 'corporation',
+          cnpj: '12345678901234',
+          social_name: 'Test Co.',
+          trade_name: 'Test Co. 2'
+          # "parent_id": 29
+        }
+      }
+    end
+
+    context 'when the request params are valid' do
+      before { post '/v1/accounts', params: account_attributes }
+
+
+      it 'creates an account' do
+        expect(json_data).not_to be_empty
+      end
+
+      it 'returns the status code 201' do
+        expect(response).to have_http_status(201)
+      end
+    end
+
+    context 'when the request params are invalid' do
+      before do
+        post '/v1/accounts',
+          params: { account: { person_type: 'Corporation' } }
+      end
+
+      it 'returns status code 422' do
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
+  describe 'PUT /v1/accounts/:id' do
+    let(:account_attributes) { { account: { name: 'Account updated' } } }
+
+    context 'when the record exists' do
+      before do
+        put "/v1/accounts/#{account_id}", params: account_attributes
+      end
+
+      it 'updates the record' do
+        expect(json_data).not_to be_empty
+      end
+
+      it 'returns the status code 200' do
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  describe 'DELETE /v1/accounts/:id' do
+    before { delete "/v1/accounts/#{account_id}" }
+
+    it 'returns status code 204' do
+      expect(response).to have_http_status(204)
+    end
+  end
+end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,0 +1,5 @@
+module RequestSpecHelper
+  def json_data
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end


### PR DESCRIPTION
* Define routes for accounts controller.
* Disable autogeneration of controller specs.
* Adds active_model_serializers for json serialization.
* Config active_model_serializers to use JsonApi as adpater.
* Creates requests specs for exposed account endpoints.
* Creates a json_data helper method to parse the request response.
* Makes the json_data helper method available to all request specs.
* Creates account data model factory.
* Creates corporation data model's factory.
* Creates individual data model's factory.
* Removes the accepts_nested_attributes_for option.
* Creates the base class for our services.
* Creates the create service to handle accounts creation.
* Creates the update service responsable for account updates.
* Creates accounts show endpoint.
* Creates account create endpoint.
* Creates account update endpoint.
* Creates account delete endpoint.
* Exposes only the used accounts endpoints.
* Creates account data model serializer.
* Creates an exception handler as a concern.
* Makes  the ExceptionHandler concern available to all the controllers.
* Fixes account request spec id data comparison.